### PR TITLE
Overhaul tweaks

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -6981,7 +6981,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                     <main class="ptx-main">
                         <!-- relax the 600px width restriction, so with    -->
                         <!-- responsive videos they grow to be much bigger -->
-                        <div class="ptx-content" style="max-width: 1600px">
+                        <div id="ptx-content" class="ptx-content" style="max-width: 1600px">
                             <!-- This is content passed in as a parameter -->
                             <xsl:copy-of select="$content" />
                           </div>
@@ -10762,7 +10762,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <xsl:apply-templates select="." mode="sidebars" />
                 <!-- HTML5 main will be a "main" landmark automatically -->
                 <main class="ptx-main">
-                    <div class="ptx-content">
+                    <div id="ptx-content" class="ptx-content">
                         <xsl:if test="$b-watermark">
                             <xsl:attribute name="style">
                                 <xsl:value-of select="$watermark-css" />
@@ -11001,7 +11001,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             <xsl:text>assistive</xsl:text>
         </xsl:attribute>
         <xsl:attribute name="href">
-            <xsl:text>#content</xsl:text>
+            <xsl:text>#ptx-content</xsl:text>
         </xsl:attribute>
         <xsl:call-template name="type-name">
             <xsl:with-param name="string-id" select="'skip-to-content'" />

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -10751,9 +10751,6 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                             <xsl:apply-templates select="$document-root/frontmatter/titlepage/editor" mode="name-list"/>
                         </p>
                     </div>  <!-- title-container -->
-                    <!-- accessibility suggests relative ordering of next items -->
-                    <xsl:call-template name="google-search-box" />
-                    <xsl:call-template name="native-search-box" />
                     <xsl:call-template name="native-search-results"/>
                 </div>  <!-- banner -->
             </header>  <!-- masthead -->
@@ -11617,6 +11614,9 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         </xsl:choose>
         <!-- Annotations button was once here, see GitHub issue -->
         <!-- https://github.com/rbeezer/mathbook/issues/1010    -->
+        <!-- Search box at end of ptx-navbar, so it can be sticky -->
+        <xsl:call-template name="google-search-box" />
+        <xsl:call-template name="native-search-box" />
     </nav>
 </xsl:template>
 

--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -6939,6 +6939,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
                 <!-- this *must* be first for maximum utility -->
                 <xsl:call-template name="skip-to-content-link" />
                 <xsl:call-template name="latex-macros" />
+                <xsl:call-template name="enable-editing" />
                  <header id="ptx-masthead">
                     <div class="ptx-banner">
                         <xsl:call-template name="brand-logo" />
@@ -10758,6 +10759,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
             </header>  <!-- masthead -->
             <xsl:apply-templates select="." mode="primary-navigation"/>
             <xsl:call-template name="latex-macros"/>
+            <xsl:call-template name="enable-editing"/>
             <div class="ptx-page">
                 <xsl:apply-templates select="." mode="sidebars" />
                 <!-- HTML5 main will be a "main" landmark automatically -->
@@ -12696,6 +12698,7 @@ TODO:
 
 <!-- PreTeXt Javascript header -->
 <xsl:template name="pretext-js">
+    <script>js_version = <xsl:value-of select="$html.js.version"/></script>
     <xsl:choose>
         <xsl:when test="not($b-debug-react)">
             <!-- condition first on toc present? -->
@@ -12865,6 +12868,17 @@ TODO:
         </xsl:call-template>
     </div>
 </xsl:template>
+
+<!-- If editing is enabled, the .ptx source file of each -->
+<!-- HTML page will be created.  We still need to set a  -->
+<!-- JavaScript variable to signal that the .ptx file    -->
+<!-- should be fetched.                                  -->
+<xsl:template name="enable-editing">
+    <xsl:if test="$debug.editable = 'yes'">
+        <script>sourceeditable = true</script>
+    </xsl:if>
+</xsl:template>
+
 
 <!-- Brand Logo -->
 <!-- Place image in masthead -->


### PR DESCRIPTION
Fixed the link for skipping to main content.

Added a JS variable to indicate editing is enabled.

Set search box to float under the navbar.

I suggest making native search the default, but I have not implemented that.