### PR TITLE
Debug: add LaTeX numbering check assertions

### DIFF
--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -4982,6 +4982,12 @@ Book (with parts), "section" at level 3
                     <xsl:when test="self::li and ancestor::list">
                         <xsl:text>:</xsl:text>
                     </xsl:when>
+                    <!-- A figure-like inside a sidebyside (or       -->
+                    <!-- sbsgroup) inside a figure is subnumbered    -->
+                    <!-- with a letter like "(a)", so the serial     -->
+                    <!-- number already carries its own delimiter    -->
+                    <!-- and no period separator is needed.          -->
+                    <xsl:when test="(&FIGURE-FILTER;) and (parent::sidebyside/parent::figure or parent::sidebyside/parent::sbsgroup/parent::figure)"/>
                     <xsl:otherwise>
                         <xsl:text>.</xsl:text>
                     </xsl:otherwise>

--- a/xsl/pretext-common.xsl
+++ b/xsl/pretext-common.xsl
@@ -424,6 +424,10 @@ $inline-solution-back|$divisional-solution-back|$worksheet-solution-back|$readin
 <xsl:param name="debug.html.annotate" select="'no'"/>
 <xsl:variable name="b-view-source" select="$debug.html.annotate = 'yes'"/>
 
+<!-- LaTeX only: verify PreTeXt-computed numbers match LaTeX counter numbers -->
+<xsl:param name="debug.numbering.check" select="''"/>
+<xsl:variable name="b-debug-numbering-check" select="$debug.numbering.check = 'yes'"/>
+
 <!-- Maybe not debugging, but transitional variables -->
 
 <!-- Prior to January 2017 we treated all whitespace as -->

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -2128,6 +2128,15 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:text>    \GenericWarning{(PreTeXt)}{PreTeXt Warning: Number mismatch for block: expected \ptx@expected, LaTeX produced \ptx@actual}%&#xa;</xsl:text>
         <xsl:text>  \fi&#xa;</xsl:text>
         <xsl:text>}&#xa;</xsl:text>
+        <xsl:text>%% Debug: verify PreTeXt division numbers match LaTeX counter numbers&#xa;</xsl:text>
+        <xsl:text>%% Second argument is a LaTeX counter name (section, chapter, etc.)&#xa;</xsl:text>
+        <xsl:text>\newcommand{\ptxdivisionnumbercheck}[2]{%&#xa;</xsl:text>
+        <xsl:text>  \protected@edef\ptx@expected{#1}%&#xa;</xsl:text>
+        <xsl:text>  \protected@edef\ptx@actual{\csname the#2\endcsname}%&#xa;</xsl:text>
+        <xsl:text>  \ifx\ptx@expected\ptx@actual\else&#xa;</xsl:text>
+        <xsl:text>    \GenericWarning{(PreTeXt)}{PreTeXt Warning: Division number mismatch for #2: expected \ptx@expected, LaTeX produced \ptx@actual}%&#xa;</xsl:text>
+        <xsl:text>  \fi&#xa;</xsl:text>
+        <xsl:text>}&#xa;</xsl:text>
         <xsl:text>\makeatother&#xa;</xsl:text>
     </xsl:if>
    <!-- Groups of environments/blocks -->
@@ -5634,6 +5643,25 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:apply-templates select="." mode="unique-id" />
     <xsl:text>}</xsl:text>
     <xsl:text>&#xa;</xsl:text>
+    <xsl:if test="$b-debug-numbering-check">
+        <xsl:variable name="the-number">
+            <xsl:apply-templates select="." mode="number"/>
+        </xsl:variable>
+        <xsl:variable name="numberless-suffix">
+            <xsl:apply-templates select="." mode="division-environment-name-suffix"/>
+        </xsl:variable>
+        <!-- Only check divisions that are numbered and use       -->
+        <!-- a numbered LaTeX environment (not numberless).       -->
+        <!-- Numberless specialized divisions (exercises, etc.)   -->
+        <!-- have a PreTeXt number but no LaTeX counter step.     -->
+        <xsl:if test="not($the-number = '') and not($numberless-suffix = '-numberless')">
+            <xsl:text>\ptxdivisionnumbercheck{</xsl:text>
+            <xsl:value-of select="$the-number"/>
+            <xsl:text>}{</xsl:text>
+            <xsl:apply-templates select="." mode="division-name"/>
+            <xsl:text>}%&#xa;</xsl:text>
+        </xsl:if>
+    </xsl:if>
     <!-- Various LaTeX classes and packages define various names, see   -->
     <!-- two links below.  The ones redefined here seem critical for    -->
     <!-- how the "titleps" package makes heads and foots, in concert    -->

--- a/xsl/pretext-latex-common.xsl
+++ b/xsl/pretext-latex-common.xsl
@@ -2117,6 +2117,19 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>]{subdisplay}{}&#xa;</xsl:text>
     <!-- faux subdisplay requires manipulating low-level counters -->
     <xsl:text>\makeatother&#xa;</xsl:text>
+    <!-- Debug: macro to compare PreTeXt-computed numbers against LaTeX counters -->
+    <xsl:if test="$b-debug-numbering-check">
+        <xsl:text>%% Debug: verify PreTeXt-computed numbers match LaTeX counter numbers&#xa;</xsl:text>
+        <xsl:text>\makeatletter&#xa;</xsl:text>
+        <xsl:text>\newcommand{\ptxnumbercheck}[1]{%&#xa;</xsl:text>
+        <xsl:text>  \protected@edef\ptx@expected{#1}%&#xa;</xsl:text>
+        <xsl:text>  \protected@edef\ptx@actual{\thetcbcounter}%&#xa;</xsl:text>
+        <xsl:text>  \ifx\ptx@expected\ptx@actual\else&#xa;</xsl:text>
+        <xsl:text>    \GenericWarning{(PreTeXt)}{PreTeXt Warning: Number mismatch for block: expected \ptx@expected, LaTeX produced \ptx@actual}%&#xa;</xsl:text>
+        <xsl:text>  \fi&#xa;</xsl:text>
+        <xsl:text>}&#xa;</xsl:text>
+        <xsl:text>\makeatother&#xa;</xsl:text>
+    </xsl:if>
    <!-- Groups of environments/blocks -->
     <!-- Variables hold exactly one node of each type in use -->
     <!-- "environment" template constructs...environments -->
@@ -5857,6 +5870,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>}</xsl:text>
     <xsl:apply-templates select="." mode="block-options"/>
     <xsl:text>%&#xa;</xsl:text>
+    <xsl:apply-templates select="." mode="debug-numbering-check"/>
     <!-- statement is required now, to be relaxed in schema             -->
     <!-- explicitly ignore PROOF-LIKE and pickup just for theorems      -->
     <!-- Alternative: ocate first PROOF-LIKE, select only preceding:: ? -->
@@ -6354,6 +6368,13 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         </xsl:otherwise>
     </xsl:choose>
     <xsl:text>%&#xa;</xsl:text>
+    <!-- Debug numbering check only for inline exercises and    -->
+    <!-- projects, which use tcolorbox auto counters.           -->
+    <!-- Divisional/worksheet/reading exercises use manual      -->
+    <!-- serial numbers, not auto counters.                     -->
+    <xsl:if test="$inline or $project">
+        <xsl:apply-templates select="." mode="debug-numbering-check"/>
+    </xsl:if>
     <!-- Each "idx" produces its own newline -->
     <xsl:apply-templates select="idx"/>
     <!-- Now the guts of the exercise, inside of its  -->
@@ -7062,6 +7083,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
     <xsl:text>}</xsl:text>
     <xsl:apply-templates select="." mode="block-options"/>
     <xsl:text>%&#xa;</xsl:text>
+    <xsl:apply-templates select="." mode="debug-numbering-check"/>
     <xsl:choose>
         <!-- We use common routines for this variant, but     -->
         <!-- components of these objects are not controllable -->
@@ -9159,6 +9181,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:apply-templates select="." mode="number"/>
     </xsl:if>
     <xsl:text>}%&#xa;</xsl:text>
+    <xsl:apply-templates select="." mode="debug-numbering-check"/>
     <!-- images have margins and widths, so centering not needed -->
     <!-- likewise, sidebyside and tabular will center themselves -->
     <!-- Eventually everything in a figure should control itself -->
@@ -9205,6 +9228,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:apply-templates select="." mode="number"/>
     </xsl:if>
     <xsl:text>}%&#xa;</xsl:text>
+    <xsl:apply-templates select="." mode="debug-numbering-check"/>
     <!-- A "list" has an introduction/conclusion, with a       -->
     <!-- list of some type in-between, and these will all      -->
     <!-- automatically word-wrap to fill the available width.  -->
@@ -11720,6 +11744,16 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
 <xsl:template match="*" mode="newpage">
     <xsl:if test="@xml:id = str:tokenize($latex-pagebreaks-string)">
         <xsl:text>\newpage%&#xa;</xsl:text>
+    </xsl:if>
+</xsl:template>
+
+<!-- Debug: emit a LaTeX assertion comparing PreTeXt's number -->
+<!-- against the number LaTeX computed from its own counters  -->
+<xsl:template match="*" mode="debug-numbering-check">
+    <xsl:if test="$b-debug-numbering-check">
+        <xsl:text>\ptxnumbercheck{</xsl:text>
+        <xsl:apply-templates select="." mode="number"/>
+        <xsl:text>}%&#xa;</xsl:text>
     </xsl:if>
 </xsl:template>
 


### PR DESCRIPTION
## Summary

- Add a debug mechanism (`-x debug.numbering.check yes`) that embeds PreTeXt-computed numbers into LaTeX source and compares them against LaTeX's own counter values at compile time
- Separate macros for block elements (`\ptxnumbercheck` via `\thetcbcounter`) and divisions (`\ptxdivisionnumbercheck` via `\csname the#2\endcsname`)
- When the flag is false, no macros are defined and nothing is emitted — zero cost

Developing the check mechanism revealed a cross-format formatting bug: subnumbered figure-like elements inside sidebyside panels produced `6.1.(a)` instead of `6.1(a)`. The period separator is now suppressed for these elements. This fix affects all output formats (LaTeX, HTML, etc.) and is a separate commit from the debug infrastructure.

## Test results

| Configuration | Block checks | Division checks | Mismatches |
|---|---|---|---|
| Sample article | 474 | 237 | 14 block (all explained) |
| Sample book — no parts | 175 | 105 | 0 |
| Sample book — decorative parts | 175 | 105 | 0 |
| Sample book — structural parts | 175 | 105 | 0 |

The 14 article mismatches: 12 from a missing `structure-number` template for `figure/sbsgroup/sidebyside/figure`, 1 from openproblem placeholder numbers, 1 from a figure inside decorative `exercises`. None are introduced by this branch — they are pre-existing bugs surfaced by the check.

## Test plan

- [ ] Build sample article and sample book with `-x debug.numbering.check yes`, confirm warnings match documented mismatches
- [ ] Build without the flag, confirm no new macros or assertions in output
- [ ] Verify HTML output only differs in subnumber formatting (`6.1(a)` vs `6.1.(a)`)

*Claude Opus 4.6, acting as a coding assistant for Rob Beezer*